### PR TITLE
Correction of a bad shift in getItemViewType

### DIFF
--- a/library/src/dev/dworks/libs/astickyheader/SectionedGridAdapter.java
+++ b/library/src/dev/dworks/libs/astickyheader/SectionedGridAdapter.java
@@ -225,7 +225,7 @@ public abstract class SectionedGridAdapter extends BaseAdapter implements Pinned
 	@Override
 	public final int getItemViewType(final int position) {
 		if (!isSectionHeaderPosition(position))
-			return getItemViewTypeExtra(position);
+			return getItemViewTypeExtra(sectionedPositionToPosition(position));
 		final int type = mSections.get(position).type;
 		return type;
 	}

--- a/library/src/dev/dworks/libs/astickyheader/SectionedListAdapter.java
+++ b/library/src/dev/dworks/libs/astickyheader/SectionedListAdapter.java
@@ -145,7 +145,7 @@ public class SectionedListAdapter extends BaseAdapter implements PinnedSectionLi
 
 	@Override
 	public int getItemViewType(final int position) {
-		return isSectionHeaderPosition(position) ? getViewTypeCount() - 1 : mBaseAdapter.getItemViewType(position);
+		return isSectionHeaderPosition(position) ? getViewTypeCount() - 1 : mBaseAdapter.getItemViewType(sectionedPositionToPosition(position));
 	}
 
 	@Override

--- a/library/src/dev/dworks/libs/astickyheader/SimpleSectionedGridAdapter.java
+++ b/library/src/dev/dworks/libs/astickyheader/SimpleSectionedGridAdapter.java
@@ -266,7 +266,7 @@ public class SimpleSectionedGridAdapter extends BaseAdapter implements PinnedSec
     public int getItemViewType(int position) {
         return isSectionHeaderPosition(position)
                 ? getViewTypeCount() - 1
-                : mBaseAdapter.getItemViewType(position);
+                : mBaseAdapter.getItemViewType(sectionedPositionToPosition(position));
     }
 
     @Override

--- a/library/src/dev/dworks/libs/astickyheader/SimpleSectionedListAdapter.java
+++ b/library/src/dev/dworks/libs/astickyheader/SimpleSectionedListAdapter.java
@@ -149,7 +149,7 @@ public class SimpleSectionedListAdapter extends BaseAdapter implements PinnedSec
     public int getItemViewType(int position) {
         return isSectionHeaderPosition(position)
                 ? getViewTypeCount() - 1
-                : mBaseAdapter.getItemViewType(position);
+                : mBaseAdapter.getItemViewType(sectionedPositionToPosition(position));
     }
 
     @Override


### PR DESCRIPTION
The method getItemViewType(int position) called in the wrapped adapter was not using the shifted position
